### PR TITLE
Changes by PaulZC

### DIFF
--- a/examples/Example22_PowerOff/Example22_PowerOff.ino
+++ b/examples/Example22_PowerOff/Example22_PowerOff.ino
@@ -32,12 +32,12 @@ SFE_UBLOX_GPS myGPS;
 // define a digital pin capable of driving HIGH and LOW
 #define WAKEUP_PIN 5
 
-// interrupt pin mapping
-#define GPS_RX     0
-#define GPS_INT0   1
-#define GPS_INT1   2
-#define GPS_SPI_CS 3
-
+// Possible GNSS interrupt pins for powerOffWithInterrupt are:
+// VAL_RXM_PMREQ_WAKEUPSOURCE_UARTRX  = uartrx
+// VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT0 = extint0 (default)
+// VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT1 = extint1
+// VAL_RXM_PMREQ_WAKEUPSOURCE_SPICS   = spics
+// These values can be or'd (|) together to enable interrupts on multiple pins
 
 void wakeUp() {
 
@@ -55,12 +55,15 @@ void wakeUp() {
 void setup() {
 
   pinMode(WAKEUP_PIN, OUTPUT);
+  digitalWrite(WAKEUP_PIN, LOW);
 
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
   Serial.println("SparkFun Ublox Example");
 
   Wire.begin();
+
+  //myGPS.enableDebugging(); // Enable debug messages
 
   if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
   {
@@ -72,7 +75,7 @@ void setup() {
   Serial.println("-- Powering off module for 20s --");
 
   myGPS.powerOff(20000);
-  // myGPS.powerOffWithInterrupt(20000, GPS_INT0);
+  //myGPS.powerOffWithInterrupt(20000, VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT0);
 
   delay(10000);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -139,8 +139,8 @@ setDynamicModel	KEYWORD2
 getDynamicModel	KEYWORD2
 powerSaveMode	KEYWORD2
 getPowerSaveMode	KEYWORD2
-powerOff KEYWORD2
-powerOffWithInterrupt KEYWORD2
+powerOff	KEYWORD2
+powerOffWithInterrupt	KEYWORD2
 
 configureMessage	KEYWORD2
 enableMessage	KEYWORD2

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -407,6 +407,12 @@ const uint32_t VAL_CFG_SUBSEC_ANTCONF = 0x00000400;	 // antConf - antenna config
 const uint32_t VAL_CFG_SUBSEC_LOGCONF = 0x00000800;	 // logConf - logging configuration
 const uint32_t VAL_CFG_SUBSEC_FTSCONF = 0x00001000;	 // ftsConf - FTS configuration (FTS products only)
 
+// Bitfield wakeupSources for UBX_RXM_PMREQ
+const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_UARTRX = 0x00000008; // uartrx
+const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT0 = 0x00000020; // extint0
+const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT1 = 0x00000040; // extint1
+const uint32_t VAL_RXM_PMREQ_WAKEUPSOURCE_SPICS = 0x00000080; // spics
+
 enum dynModel // Possible values for the dynamic platform model, which provide more accuract position output for the situation. Description extracted from ZED-F9P Integration Manual
 {
 	DYN_MODEL_PORTABLE = 0, //Applications with low acceleration, e.g. portable devices. Suitable for most situations.
@@ -642,7 +648,7 @@ public:
 	boolean powerSaveMode(bool power_save = true, uint16_t maxWait = 1100);
 	uint8_t getPowerSaveMode(uint16_t maxWait = 1100); // Returns 255 if the sendCommand fails
 	boolean powerOff(uint32_t durationInMs, uint16_t maxWait = 1100);
-	boolean powerOffWithInterrupt(uint32_t durationInMs, uint8_t wakeupPin = 1, boolean forceWhileUsb = true, uint16_t maxWait = 1100);
+	boolean powerOffWithInterrupt(uint32_t durationInMs, uint32_t wakeupSources = VAL_RXM_PMREQ_WAKEUPSOURCE_EXTINT0, boolean forceWhileUsb = true, uint16_t maxWait = 1100);
 
 	//Change the dynamic platform model using UBX-CFG-NAV5
 	boolean setDynamicModel(dynModel newDynamicModel = DYN_MODEL_PORTABLE, uint16_t maxWait = 1100);


### PR DESCRIPTION
Hi @unsurv,
Thanks again for submitting your PR #116. It was good but needed a few corrections. If you merge this PR into your master branch, we can then get PR #116 merged into the main SparkFun master branch.
The changes are:
- Added definitions for the four wakeupSources pins so they can be or'd together if necessary
- Changed wakeupPin (uint8_t) to wakeupSources (uint32_t) in powerOffWithInterrupt
- Changed the spaces to tabs in keywords.txt
- Added payloadCfg[4-7] to powerOff. It is important that these get set correctly.
- Added payloadCfg[1-3] to powerOffWithInterrupt. It is important these are set to zero and not left undefined.
- Corrected the order of payloadCfg[8-11] in powerOffWithInterrupt. These were big endian but need to be little endian.
- Corrected the value for payloadCfg[8] when forceWhileUSB is true (needs to be 0x06 not 0x04).
- Set payloadCfg[12-15] in powerOffWithInterrupt according to wakeupSources.
All the best,
Paul